### PR TITLE
Strip simple quoted property name

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="yaml-utils.ZPM">
     <Module>
       <Name>yaml-utils</Name>
-      <Version>0.1.2</Version>
+      <Version>0.1.3</Version>
       <Description>Simple ObjectScript YAML-to-JSON converter</Description>
       <Packaging>module</Packaging>
       <SourcesRoot>src</SourcesRoot>

--- a/src/cls/YAML/Utils.cls
+++ b/src/cls/YAML/Utils.cls
@@ -74,7 +74,7 @@ ClassMethod StreamToJSON(yaml As %Stream.Object, Output sc As %Status) As %Dynam
 			
 			set colon = $find(stripped,":")
 			if (colon) {
-				set key = $zstrip($e(stripped,$s(isArray:2,1:1),colon-2),"<>W"), 
+				set key = $zstrip($e(stripped,$s(isArray:2,1:1),colon-2),"<>W","'"), 
 					value = $zstrip($e(stripped,colon,*),"<W")
 				
 				if $e(value)="[" {


### PR DESCRIPTION
Hi @bdeboe ,

I noticed if we have a YAML with a 'quoted' property like that: 

```yaml
paths:
  /test:
    get:
      responses:
        '200':
          description: OK
```
The result is : 

```json
{
  "paths":{
    "/test":{
      "get":{
        "responses":{
          "'200'":{
            "description":"OK"
          }
        }
      }
    }
}
```

The result for the property is `'200'`, but I think we can strip the leading and trailing quote to produce `200` in JSON format.  
Let me know what do you think about that and if you agree, the pull request is ready.
This is related to an [issue in openapi-suite](https://github.com/lscalese/OpenAPI-Client-Gen/issues/34)

Thank you.
Lorenzo.